### PR TITLE
Updated to work with VSTS Release Management

### DIFF
--- a/automation/CreateDataSource.ps1
+++ b/automation/CreateDataSource.ps1
@@ -16,7 +16,7 @@
  Import-Module (Join-Path (Join-Path $PSScriptRoot "lib") "DataSource.psm1") -DisableNameChecking
  Import-Module (Join-Path (Join-Path $PSScriptRoot "lib") "Definition.psm1") -DisableNameChecking
 
- $ErrorActionPreference = "Stop"
+ $ErrorActionPreference = 'Continue'
 
  Set-Credentials $serviceName $serviceKey
   
@@ -24,8 +24,16 @@
 
  $credentials = @{ "connectionString" = $connectionString }
  $definition.credentials = $credentials
+ 
+ try
+ {
+    $dataSource = Get-DataSource $definition.name
+ }
+ catch [System.Net.WebException]
+ {
+    $dataSource = $null
+ }
 
- $dataSource = Get-DataSource $definition.name
  if ($dataSource -ne $null)
  {
     Delete-DataSource $definition.name

--- a/automation/CreateIndex.ps1
+++ b/automation/CreateIndex.ps1
@@ -13,13 +13,21 @@
  Import-Module (Join-Path (Join-Path $PSScriptRoot "lib") "Index.psm1") -DisableNameChecking
  Import-Module (Join-Path (Join-Path $PSScriptRoot "lib") "Definition.psm1") -DisableNameChecking
 
- $ErrorActionPreference = "Stop"
+ $ErrorActionPreference = 'Continue'
 
  Set-Credentials $serviceName $serviceKey
   
  $definition = Get-Definition $definitionName
 
- $index = Get-Index $definition.name
+ try
+ {
+    $index = Get-Index $definition.name
+ }
+ catch [System.Net.WebException]
+ {
+    $index = $null
+ }
+
  if ($index -ne $null)
  {
     Delete-Index $definition.name

--- a/automation/CreateIndexer.ps1
+++ b/automation/CreateIndexer.ps1
@@ -13,13 +13,20 @@
  Import-Module (Join-Path (Join-Path $PSScriptRoot "lib") "Indexer.psm1") -DisableNameChecking
  Import-Module (Join-Path (Join-Path $PSScriptRoot "lib") "Definition.psm1") -DisableNameChecking
 
- $ErrorActionPreference = "Stop"
+ $ErrorActionPreference = 'Continue'
 
  Set-Credentials $serviceName $serviceKey
   
  $definition = Get-Definition $definitionName
 
- $indexer = Get-Indexer $definition.name
+ try
+ {
+    $indexer = Get-Indexer $definition.name
+ }
+ catch [System.Net.WebException]
+ {
+    $indexer = $null
+ }
  if ($indexer -ne $null)
  {
     Delete-Indexer $definition.name


### PR DESCRIPTION
Resolved an issue where Azure PowerShell scripting would end because of a 404 HTTP Error if target items did not exist already.